### PR TITLE
Notes on go generics

### DIFF
--- a/notes/languages/go.md
+++ b/notes/languages/go.md
@@ -768,14 +768,25 @@ constraint on Go having an odd type system is that Go had previous design
 decisions and constraints that make designing a proper parametric types system
 impossible.
 
-Go has a constraint, for the sake of simplicity, that operators are not first
-class citizens. They are magical citizens, that are there, they work, they
-are used all the time, but you can't define them, you can't manipulate them,
-you can't talk about them.
+Impossible is a strong word, because it is always possible to do something,
+just as was possible to add namespaces/isolation on Linux, it is just much
+more complex and clumsy than on systems that were designed with this idea
+from the ground up like Plan9/Inferno/Fuchsia.
 
-For example, there never was a way in Go (and still there isn't) a way to define
-an interface saying "I want all comparable types". You can define an interface
-like:
+By impossible I mean, you won't have a nice result, specially not a result
+comparable to another system that was designed with the ground up with the
+idea in mind. This is an instance of the principle that not everything can
+be implemented in an ad-hoc manner. Some things need to be embedded on the
+design from the first day up, they don't lend themselves easily to be added
+later, after a lot of other design decisions are incompatible with it.
+
+Well, going back to Go. Go has a constraint, for the sake of simplicity, that
+operators are not first class citizens. They are magical citizens, that are
+there, they work, they are used all the time, but you can't define them,
+you can't manipulate them, you can't talk about them.
+
+For example, there never was a way in Go (and still there isn't) to define
+an interface saying "I want all comparable types". You can define an interface like:
 
 ```go
 type equal interface {
@@ -785,8 +796,8 @@ type equal interface {
 
 But now you need to use a method Equal and feel all Javaesque about things =P.
 
-That is a decision with its own tradeoffs, there is a lot of ways to create
-messes with operator overloading, but if you write generic algorithms
+That is a decision with its own trade-offs, there is a lot of ways to create
+messes with operator definitions, but if you want to write generic algorithms
 seamlessly, in a way that they read well and are easy to use, support to operators
 as first class citizens is fundamental.
 

--- a/notes/languages/go.md
+++ b/notes/languages/go.md
@@ -872,6 +872,7 @@ Depending on other barriers found, the language may end up with more magical
 constraints, since obviously not everything that should be possible in a parametric
 polymorphic system is actually possible.
 
+
 #### Messed Up Interfaces
 
 This one is less a limitation on the parametric type system and more a
@@ -928,6 +929,27 @@ type a interface {
 Or any variant of the idea that allows you to express that you want any
 type that implements the `==` operator, which is nothing special, just a function
 with a nice syntax to be called.
+
+They even created a whole theory around "type sets" trying to get their head
+around how Go type system would be, the idea is that constraints always define
+sets of types. I still don't get the idea, because honestly most useful type
+sets for interfaces/constraints are infinite because you care about
+operations/protocols not actual set of types.
+
+For any interface, there can always be another implementation
+of it, since it is any type that has all the necessary methods. For a given program
+the sets are always limited, you can always calculate them for that program, but
+conceptually they are infinite. Think about an interface in a library, you don't know
+how much types in the world implement it, and you shouldn't need to know, that is the
+source of the power of interfaces, they are very easy to be used in ways not
+imagined by their authors.
+
+But then Go created this aberration where you can actually created a finite set,
+which is rarely what you want. For example, the previously mentioned `comparable`
+constraint only exists because you want an infinite set, there may be more and more
+types in your program that works with `==`, you don't want to add each one manually
+in a constraint for things to work. Since that is impossible in this new type
+system, hey had to use a hack.
 
 It is interesting to observe how these design decisions ripple through the
 entire language. Language design is hard :-).

--- a/notes/languages/go.md
+++ b/notes/languages/go.md
@@ -845,7 +845,7 @@ func main() {
 
 So this works and is possible, but only thanks to Go introducing more magical
 concepts that you can't implement yourself. Go already used to do that, it has a lot
-of builtins that are generic and just work nicely. That is an OK design decision
+of built-ins that are generic and just work nicely. That is an OK design decision
 in a language, but the whole purpose of a language that has a proper parametric
 polymorphic system is that any of that is not needed, if you design a language
 from scratch with that idea in mind the type system should be powerful enough
@@ -860,3 +860,12 @@ you, so you still need the complexity of magical language defined constraints.
 Depending on other barriers found, the language may end up with more magical
 constraints, since obviously not everything that should be possible in a parametric
 polymorphic system is actually possible.
+
+#### Sorting
+
+TODO
+
+#### Messed Up Interfaces
+
+This one is less a limitation on the parametric type system and more a
+bad choice, IMHO, on how to define constraints.


### PR DESCRIPTION
I have been thinking about some of the quirkiness of Go generics for some time, decided to write down some of the stuff. Language design is hard...but I still can't shake the feeling that pushing parametric types in Go was a mistake, not that parametric types can't be useful, but it is not something that can be added on a language as an after thought. Java was an example..sadly now is Go.

I'm not an specialist on sophisticated type systems, so reading this is probably a waste of time =P